### PR TITLE
Development -> V4.0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Here is a list of what these raw values stand for:
 
 ## Changelog
 
+### V4.0.20 (2021-04-30) (Sleepwalkers)
+* (grizzelbee) Fix: [137](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/137) Fixed setting no ACK-Flag for info.connection
+
 ### V4.0.19 (2021-04-29) (The scarecrow)
 * (grizzelbee) Fix: Fixed light switch bug causing an exception when switching - 2nd attempt
 * (grizzelbee) Fix: Fixed No-Icon Bug when appliance is unknown

--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ Here is a list of what these raw values stand for:
 ## Changelog
 
 ### V4.0.20 (2021-04-30) (Sleepwalkers)
-* (grizzelbee) Fix: [137](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/137) Fixed setting no ACK-Flag for info.connection
+* (grizzelbee) Fix: [137](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/137) Fixed Read-only state "info.connection" has been written without ack-flag with value "false"
+* (grizzelbee) Fix: [138](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/138) Fixed State value to set for ".Schleuderdrehzahl" has wrong type "string" but has to be "number"
+* (grizzelbee) Fix: [139](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/139) Fixed State value to set for ".ACTIONS.Light" has wrong type "number" but has to be "string" 
+
 
 ### V4.0.19 (2021-04-29) (The scarecrow)
 * (grizzelbee) Fix: Fixed light switch bug causing an exception when switching - 2nd attempt

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Here is a list of what these raw values stand for:
 * (grizzelbee) Fix: [137](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/137) Fixed Read-only state "info.connection" has been written without ack-flag with value "false"
 * (grizzelbee) Fix: [138](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/138) Fixed State value to set for ".Schleuderdrehzahl" has wrong type "string" but has to be "number"
 * (grizzelbee) Fix: [139](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/139) Fixed State value to set for ".ACTIONS.Light" has wrong type "number" but has to be "string" 
-
+* (grizzelbee) Upd: Changed device group from channel to folder  as documented [here](https://github.com/ioBroker/ioBroker.docs/blob/master/docs/en/dev/objectsschema.md)
 
 ### V4.0.19 (2021-04-29) (The scarecrow)
 * (grizzelbee) Fix: Fixed light switch bug causing an exception when switching - 2nd attempt

--- a/io-package.json
+++ b/io-package.json
@@ -1,9 +1,9 @@
 {
     "common": {
         "name": "mielecloudservice",
-        "version": "4.0.19",
+        "version": "4.0.20",
         "news": {
-            "4.0.19": {
+            "4.0.20": {
                 "en": "Bugfix Release - see full changelog since your last version for details!",
                 "de": "Bugfix Release - Bitte sehen Sie sich das vollständige Änderungsprotokoll seit Ihrer aktuell eingesetzten Version an!",
                 "ru": "Выпуск Bugfix - подробности смотрите в полном журнале изменений с момента выхода последней версии!",

--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ function startadapter(options) {
                 }
                 adapter.unsubscribeObjects('*');
                 adapter.unsubscribeStates('*');
-                adapter.setState('info.connection', false);
+                adapter.setState('info.connection', false, true);
                 if (_auth.refresh_token) {
                     await mieleAPITools.APILogOff(adapter, _auth, "refresh_token")
                 }
@@ -108,7 +108,7 @@ function startadapter(options) {
                         });
                 } else {
                     adapter.log.warn('Adapter config is invalid. Please fix.');
-                    adapter.setState('info.connection', false);
+                    adapter.setState('info.connection', false, true);
                     adapter.terminate('Invalid Configuration.', 11);
                 }
         }
@@ -332,7 +332,7 @@ async function addMieleDevice(path, mieleDevice, setup){
         common: {name:   (mieleDevice.ident.deviceName === ''? mieleDevice.ident.type.value_localized: mieleDevice.ident.deviceName),
             read: true,
             write: false,
-            icon: _knownDevices[mieleDevice.ident.deviceIdentLabel.fabNumber].icon
+            icon: icon
         },
         native: {}
     }, null);
@@ -681,7 +681,7 @@ async function main() {
         }
     } catch(err) {
         adapter.log.error('[main] :' + err.message + ', Stacktrace:' + err.stack);
-        adapter.setState('info.connection', false);
+        adapter.setState('info.connection', false, true);
     }
 }//End Function main
 

--- a/main.js
+++ b/main.js
@@ -73,7 +73,7 @@ function startadapter(options) {
                 adapter.log.debug(`stateChange: DeviceId [${deviceId}], requested action [${action}], state [${state.val}]`);
                 const actions = await mieleAPITools.getPermittedActions(adapter, _auth,  _knownDevices[deviceId].API_Id );
                 adapter.log.debug(`stateChange: permitted actions for device [${deviceId}]->[${JSON.stringify(actions)}]`);
-                await mieleAPITools.APIStartAction(adapter, _auth, id, action, state.val, false, _knownDevices, actions);
+                await mieleAPITools.APIStartAction(adapter, _auth, id, action, state.val, false, _knownDevices);
             }
           },
         // stateChange: function(id, state){
@@ -400,7 +400,7 @@ async function addMieleDeviceState(path, currentDevice, currentDeviceState, setu
                 await mieleTools.createStateMobileStart(adapter, setup, path, currentDeviceState.remoteEnable.mobileStart);
                 await mieleTools.createStateEstimatedEndTime(adapter, setup, path, currentDeviceState.remainingTime);
                 await mieleTools.createStateElapsedTime(adapter, setup, path, currentDeviceState.elapsedTime);
-                await mieleTools.createStateSpinningSpeed(adapter, setup, `${path}.${currentDeviceState.spinningSpeed.key_localized}`, currentDeviceState.spinningSpeed.value_localized, currentDeviceState.spinningSpeed.unit);
+                await mieleTools.createStateSpinAPIStartActionningSpeed(adapter, setup, `${path}.${currentDeviceState.spinningSpeed.key_localized}`, currentDeviceState.spinningSpeed.value_localized, currentDeviceState.spinningSpeed.unit);
                 await mieleTools.createStateEcoFeedbackEnergy(adapter, setup, path, currentDeviceState.ecoFeedback);
                 await mieleTools.createStateEcoFeedbackWater(adapter, setup, path, currentDeviceState.ecoFeedback);
                 // actions

--- a/main.js
+++ b/main.js
@@ -257,7 +257,7 @@ function getDeviceObj(deviceTypeID){
             break;
     }
     mieleTools.createExtendObject(adapter, deviceObj.deviceFolder, {
-        type: 'channel',
+        type: 'folder',
         common: deviceObj,
         native: {}
     }, null);

--- a/miele-Tools.js
+++ b/miele-Tools.js
@@ -187,7 +187,7 @@ module.exports.addLightSwitch = async function(adapter, path, actions, value){
                     "read": true,
                     "write": state !== 0,
                     "role": 'switch',
-                    "type": 'string',
+                    "type": 'number',
                     "states":{0:'None', 1:'On', 2:'Off'}
                 },
                 native: {}

--- a/miele-Tools.js
+++ b/miele-Tools.js
@@ -1583,7 +1583,7 @@ module.exports.createStateEcoFeedbackEnergy = function(adapter, setup, path, eco
  * @param adapter {object} link to the adapter instance
  * @param setup {boolean} indicator whether the devices need to setup or only states are to be updated
  * @param path {string} path where the data point is going to be created
- * @param value {number} value to set to the data point
+ * @param value {string} value to set to the data point
  * @param unit {string} unit the value is in
  */
 module.exports.createStateSpinningSpeed = function(adapter, setup, path, value, unit) {
@@ -1592,7 +1592,7 @@ module.exports.createStateSpinningSpeed = function(adapter, setup, path, value, 
         setup,
         path,
         'Spinning speed of a washing machine.',
-        value,
+        Number.parseInt(value),
         unit,
         'value');
 }

--- a/miele-apiTools.js
+++ b/miele-apiTools.js
@@ -48,7 +48,7 @@ module.exports.APIGetAccessToken = async function (adapter) {
         adapter.expiryDate = new Date();
         adapter.expiryDate.setSeconds(adapter.expiryDate.getSeconds() + auth.hasOwnProperty('expires_in') ? auth.expires_in : 0);
         adapter.log.info('Access-Token expires at:  [' + adapter.expiryDate.toString() + ']');
-        adapter.setState('info.connection', true);
+        adapter.setState('info.connection', true, true);
         return auth;
     } catch (error) {
         adapter.log.error('OAuth2 returned an error during first login!');
@@ -181,10 +181,9 @@ module.exports.getPermittedActions = async function (adapter, auth, deviceId){
  * @param value {string} the value of the action to set
  * @param setup {boolean} indicator whether the devices need to setup or only states are to be updated
  * @param knownDevices {object} Array of known devices with a reference from their serial to the API_Id
- * @param actions {object} JSON structure with all currently permitted actions for the given device
  *
  */
-module.exports.APIStartAction = async function(adapter, auth, path, action, value, setup, knownDevices, actions) {
+module.exports.APIStartAction = async function(adapter, auth, path, action, value, setup, knownDevices) {
     let currentAction;
     let paths = path.split('.');    // transform into array
     paths.pop();                    // remove last element of path
@@ -197,6 +196,7 @@ module.exports.APIStartAction = async function(adapter, auth, path, action, valu
         case 'Light':
             if (Number.parseInt(value) === 0){
                 adapter.log.warn('You cannot switch light to state "none". That\'s senseless.');
+                adapter.setState(currentPath + '.Action_Information', 'You cannot switch light to state "none". That\'s senseless.', true);
                 return;
             } else if (Number.parseInt(value) === mieleConst.LIGHT_ON){
                 currentAction = {'light':mieleConst.LIGHT_ON};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.mielecloudservice",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "description": "Integrates your MieleCloudService (aka Miele@Home) Devices to ioBroker",
   "author": {
     "name": "grizzelbee",


### PR DESCRIPTION
### V4.0.20 (2021-04-30) (Sleepwalkers)
* (grizzelbee) Fix: [137](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/137) Fixed Read-only state "info.connection" has been written without ack-flag with value "false"
* (grizzelbee) Fix: [138](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/138) Fixed State value to set for ".Schleuderdrehzahl" has wrong type "string" but has to be "number"
* (grizzelbee) Fix: [139](https://github.com/Grizzelbee/ioBroker.mielecloudservice/issues/139) Fixed State value to set for ".ACTIONS.Light" has wrong type "number" but has to be "string" 
* (grizzelbee) Upd: Changed device group from channel to folder  as documented [here](https://github.com/ioBroker/ioBroker.docs/blob/master/docs/en/dev/objectsschema.md)
