### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "main.js"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18"
   },
   "scripts": {
     "test:js": "mocha --config test/mocharc.custom.json \"{!(node_modules|test)/**/*.test.js,*.test.js,test/**/test!(PackageFiles|Startup).js}\"",


### PR DESCRIPTION
Adapter is tested against node 18 / 20 only.
Node 14 and node 16 are outdated since onths and no longer maintained.

Hance adapter should require node 18 as minimum.

Please merge PR / adapter engines clause for next release. An urgent extra release is not required as repository build talkes repository head revision anyway. 