### PR TITLE
Fix test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -5,7 +5,7 @@ name: Test and Release
 on:
   push:
     branches:
-      - "main"
+      - "master"
     tags:
       # normal versions
       - "v[0-9]+.[0-9]+.[0-9]+"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,8 @@ export default [
             'admin/build',
             'admin/words.js',
             'admin/admin.d.ts',
-            '**/adapter-config.d.ts'
+            '**/adapter-config.d.ts',
+            'lib/tools.js'
         ]
     },
 


### PR DESCRIPTION
This PR corrects the branch used at test-and.-release so that test are executed correctly.

This PR excludes lib/tools.js as this file is outdated an most likely not used any more.

NOTE:
Tlinter currently still fails as @ts-ignore is depracted and should be replyced by @ts-expect-error. Please adapt your code.

