### PR TITLE
Guard JSON.parse on DEVICES and ACTIONS SSE payloads

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -258,12 +258,41 @@ class Mielecloudservice extends utils.Adapter {
     }
 
     /**
+     * Parse the JSON payload of an SSE 'action' event. Returns null if the
+     * payload is not valid JSON so the listener can skip the message instead
+     * of crashing the adapter when the Miele backend sends a truncated or
+     * malformed frame.
      *
-     * @param {string} data
-     * @returns {actionMessage}
+     * @param {string} data raw event.data string from the SSE stream
+     * @returns {actionMessage | null} parsed action message, or null on parse error
      */
-    getActionMessage(data){
-        return JSON.parse(data);
+    getActionMessage(data) {
+        try {
+            return JSON.parse(data);
+        } catch (err) {
+            const sample = typeof data === 'string' ? data.slice(0, 200) : String(data);
+            this.log.warn(`Could not parse SSE ACTIONS payload: [${err}] — payload: [${sample}]`);
+            return null;
+        }
+    }
+
+    /**
+     * Parse the JSON payload of an SSE 'device' event. Returns null if the
+     * payload is not valid JSON so the listener can skip the message instead
+     * of crashing the adapter when the Miele backend sends a truncated or
+     * malformed frame.
+     *
+     * @param {string} data raw event.data string from the SSE stream
+     * @returns {object | null} parsed device payload, or null on parse error
+     */
+    getDeviceMessage(data) {
+        try {
+            return JSON.parse(data);
+        } catch (err) {
+            const sample = typeof data === 'string' ? data.slice(0, 200) : String(data);
+            this.log.warn(`Could not parse SSE DEVICES payload: [${err}] — payload: [${sample}]`);
+            return null;
+        }
     }
 
     /**
@@ -293,7 +322,11 @@ class Mielecloudservice extends utils.Adapter {
         this.log.info(`Registering for 'Devices' events at Miele API.`);
         events.addEventListener(mieleConst.DEVICES, async event => {
             this.log.debug(`Received DEVICES message by SSE: [${JSON.stringify(event.data)}]`);
-            await mieleTools.splitMieleDevices(this, JSON.parse(event.data), tokenSet)
+            const message = this.getDeviceMessage(event.data);
+            if (message === null) {
+                return;
+            }
+            await mieleTools.splitMieleDevices(this, message, tokenSet)
             .catch(err => {
                 this.log.warn(`splitMieleDevices crashed with error: [${err}]`);
             })
@@ -309,7 +342,11 @@ class Mielecloudservice extends utils.Adapter {
         this.log.info(`Registering for 'Action' events at Miele API.`);
         events.addEventListener(mieleConst.ACTIONS, event => {
             this.log.debug(`Received ACTIONS message by SSE: [${JSON.stringify(event.data)}]`);
-            mieleTools.splitMieleActionsMessage(this, this.getActionMessage(event.data)).catch(err => {
+            const message = this.getActionMessage(event.data);
+            if (message === null) {
+                return;
+            }
+            mieleTools.splitMieleActionsMessage(this, message).catch(err => {
                 this.log.warn(`splitMieleActionsMessage crashed with error: [${err}]`);
             });
         });


### PR DESCRIPTION
This picks up the connection-robustness work started in [`ff956d8`](https://github.com/Grizzelbee/ioBroker.mielecloudservice/commit/ff956d8857079d952555d1a40968d8466b45a0c7) (`trying to fix connection issue`). That commit extracted the ACTIONS-parse into a `getActionMessage(data)` helper but kept it as a bare `JSON.parse(data)`, so a truncated or malformed SSE frame still crashes the listener — and the matching `splitMieleDevices(JSON.parse(event.data), tokenSet)` in the DEVICES branch is unguarded too.

## What changes

- `getActionMessage(data)` gains a try/catch; on parse error it logs a `warn` with the underlying error and a 200-char payload sample, then returns `null`.
- `getDeviceMessage(data)` is added with the same shape; the DEVICES listener now goes through it instead of calling `JSON.parse` inline.
- Both listeners check for the `null` return and skip processing the bad frame, so a malformed payload no longer takes the EventSource subscription down with it.

```diff
-            await mieleTools.splitMieleDevices(this, JSON.parse(event.data), tokenSet)
+            const message = this.getDeviceMessage(event.data);
+            if (message === null) {
+                return;
+            }
+            await mieleTools.splitMieleDevices(this, message, tokenSet)
```

```diff
-            mieleTools.splitMieleActionsMessage(this, this.getActionMessage(event.data)).catch(err => {
+            const message = this.getActionMessage(event.data);
+            if (message === null) {
+                return;
+            }
+            mieleTools.splitMieleActionsMessage(this, message).catch(err => {
```

## Scope notes

- Targets `development` (the active v7 branch). Nothing on `master`/v6 is touched.
- File was not auto-formatted with prettier — existing style stays as-is, `eslint` output for `source/main.js` is identical or slightly better than before this PR.
- No tests added: the existing `test/testdata.actions.json` / `test/testdata.devices.json` files exercise the happy path, and the failure mode here is "skip the message and warn", which is hard to assert meaningfully without mocking the SSE transport.